### PR TITLE
Feature - Collisions

### DIFF
--- a/src/main/java/fr/LaurentFE/pacManClone/GameMap.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/GameMap.java
@@ -1,5 +1,6 @@
 package fr.LaurentFE.pacManClone;
 
+import java.awt.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -87,9 +88,12 @@ public class GameMap {
         return usable;
     }
 
-    public TileType getTile(int x, int y) {
-        if (x >= 0 && x < mapWidthTile && y >= 0 && y < mapHeightTile) {
-            return map[y][x];
+    public TileType getTile(Point position) {
+        if (position.x >= 0
+                && position.x < mapWidthTile
+                && position.y >= 0
+                && position.y < mapHeightTile) {
+            return map[position.y][position.x];
         }
         return TileType.UNDEFINED;
     }

--- a/src/main/java/fr/LaurentFE/pacManClone/PacMan.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/PacMan.java
@@ -8,7 +8,6 @@ public class PacMan {
     private int currentMouthAngle;
     private int mouthAngleIncrement;
     private final int moveSpeed;
-    private boolean isMoving;
     private final Rectangle hitBox;
     private final int tileSize;
     private final int size;
@@ -22,7 +21,6 @@ public class PacMan {
         maxMouthAngle = 90;
         currentMouthAngle = maxMouthAngle;
         mouthAngleIncrement = -5;
-        isMoving = false;
     }
 
     public void animateMouth() {
@@ -37,7 +35,6 @@ public class PacMan {
     }
 
     public void move() {
-        if(isMoving) {
             if (orientation == Orientation.LEFT) {
                 hitBox.x = hitBox.x - moveSpeed;
             } else if (orientation == Orientation.RIGHT) {
@@ -47,7 +44,6 @@ public class PacMan {
             } else if (orientation == Orientation.DOWN) {
                 hitBox.y = hitBox.y + moveSpeed;
             }
-        }
     }
 
     public void bumpOutOfCollision(Point collisionTileMapPosition) {
@@ -67,7 +63,6 @@ public class PacMan {
     }
 
     public void changeOrientation(Orientation orientation) {
-        isMoving = true;
         this.orientation = orientation;
     }
 

--- a/src/main/java/fr/LaurentFE/pacManClone/PacMan.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/PacMan.java
@@ -1,20 +1,28 @@
 package fr.LaurentFE.pacManClone;
 
+import java.awt.*;
+
 public class PacMan {
-    private int x;
-    private int y;
     private Orientation orientation;
     private final int maxMouthAngle;
     private int currentMouthAngle;
     private int mouthAngleIncrement;
+    private final int moveSpeed;
+    private boolean isMoving;
+    private final Rectangle hitBox;
+    private final int tileSize;
+    private final int size;
 
-    public PacMan(int startingX, int startingY, Orientation startingOrientation) {
-        x = startingX;
-        y = startingY;
+    public PacMan(Point startingPosition, int tileSize, int size, Orientation startingOrientation, int moveSpeed) {
+        this.size = size;
+        this.tileSize = tileSize;
+        hitBox = new Rectangle(startingPosition.x, startingPosition.y, tileSize, tileSize);
         orientation = startingOrientation;
+        this.moveSpeed = moveSpeed;
         maxMouthAngle = 90;
         currentMouthAngle = maxMouthAngle;
-        mouthAngleIncrement = -9;
+        mouthAngleIncrement = -5;
+        isMoving = false;
     }
 
     public void animateMouth() {
@@ -28,32 +36,54 @@ public class PacMan {
         }
     }
 
-
-    public int getX() {
-        return x;
+    public void move() {
+        if(isMoving) {
+            if (orientation == Orientation.LEFT) {
+                hitBox.x = hitBox.x - moveSpeed;
+            } else if (orientation == Orientation.RIGHT) {
+                hitBox.x = hitBox.x + moveSpeed;
+            } else if (orientation == Orientation.UP) {
+                hitBox.y = hitBox.y - moveSpeed;
+            } else if (orientation == Orientation.DOWN) {
+                hitBox.y = hitBox.y + moveSpeed;
+            }
+        }
     }
 
-    public void offsetX(int x) {
-        this.x += x;
-    }
-
-    public int getY() {
-        return y;
-    }
-
-    public void offsetY(int y) {
-        this.y += y;
+    public void bumpOutOfCollision(Point collisionTileMapPosition) {
+        if (orientation == Orientation.LEFT) {
+            hitBox.x = collisionTileMapPosition.x * tileSize + tileSize;
+        } else if (orientation == Orientation.RIGHT) {
+            hitBox.x = collisionTileMapPosition.x * tileSize - tileSize;
+        } else if (orientation == Orientation.UP) {
+            hitBox.y = collisionTileMapPosition.y * tileSize + tileSize;
+        } else if (orientation == Orientation.DOWN) {
+            hitBox.y = collisionTileMapPosition.y * tileSize - tileSize;
+        }
     }
 
     public Orientation getOrientation() {
         return orientation;
     }
 
-    public void setOrientation(Orientation orientation) {
+    public void changeOrientation(Orientation orientation) {
+        isMoving = true;
         this.orientation = orientation;
     }
 
     public int getCurrentMouthAngle() {
         return currentMouthAngle;
+    }
+
+    public Rectangle getHitBox() {
+        return hitBox;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public Point getPosition() {
+        return hitBox.getLocation();
     }
 }


### PR DESCRIPTION
PacMan now collides with the labyrinth. 
Collisions are tested for each corner of PacMan's square hitbox, and they must never be on top of a tile that is not a PATH. If it happens, PacMan is bumped into the correct position closest to the tile he just collided with.

Controls will evolve to match the original game's controls. 
Right now collisions make it hard to navigate in the corridors, but it's working as intended.