### PR TITLE
Refacto - TileIndex and Position

### DIFF
--- a/src/main/java/fr/LaurentFE/pacManClone/GameMap.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/GameMap.java
@@ -1,6 +1,5 @@
 package fr.LaurentFE.pacManClone;
 
-import java.awt.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -14,7 +13,7 @@ public class GameMap {
     private final int mapWidthTile;
     private final TileType[][] map;
     private boolean usable;
-    private Point ghostHouse;
+    private TileIndex ghostHouse;
 
     private GameMap() {
         mapHeightTile = 36;
@@ -82,7 +81,7 @@ public class GameMap {
                     default -> TileType.UNDEFINED;
                 };
                 if (map[y][x] == TileType.GHOSTHOUSE) {
-                    ghostHouse = new Point(x, y);
+                    ghostHouse = new TileIndex(x, y);
                 } else if (map[y][x] == TileType.UNDEFINED) {
                     System.err.println("Undefined tile type in tile map : "+tile);
                     return false;
@@ -103,7 +102,7 @@ public class GameMap {
         return mapWidthTile;
     }
 
-    public Point getGhostHouse() {
+    public TileIndex getGhostHouse() {
         return ghostHouse;
     }
 
@@ -111,12 +110,12 @@ public class GameMap {
         return usable;
     }
 
-    public TileType getTile(Point position) {
-        if (position.x >= 0
-                && position.x < mapWidthTile
-                && position.y >= 0
-                && position.y < mapHeightTile) {
-            return map[position.y][position.x];
+    public TileType getTile(TileIndex tileIndex) {
+        if (tileIndex.x >= 0
+                && tileIndex.x < mapWidthTile
+                && tileIndex.y >= 0
+                && tileIndex.y < mapHeightTile) {
+            return map[tileIndex.y][tileIndex.x];
         }
         return TileType.UNDEFINED;
     }

--- a/src/main/java/fr/LaurentFE/pacManClone/GamePanel.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/GamePanel.java
@@ -21,37 +21,37 @@ public class GamePanel extends JPanel implements Runnable {
     private static final Orientation DEFAULT_ORIENTATION = Orientation.RIGHT;
     private static final int MOVE_SPEED = TILE_SIZE /8;
     public static final PacMan PAC_MAN = new PacMan(
-            new Point(TILE_SIZE *13, TILE_SIZE *26),
+            new TileIndex(13, 26).toPosition(),
             DEFAULT_ORIENTATION,
             MOVE_SPEED);
     public static final Ghost BLINKY = new Ghost(
-            new Point(TILE_SIZE *9, TILE_SIZE *14),
+            new TileIndex(9, 14).toPosition(),
             DEFAULT_ORIENTATION,
             MOVE_SPEED,
             Color.RED,
             new Blinky(),
-            new Point(0,0));
+            new TileIndex(0,0));
     public static final Ghost PINKY = new Ghost(
-            new Point(TILE_SIZE *18, TILE_SIZE *14),
+            new TileIndex(18, 14).toPosition(),
             DEFAULT_ORIENTATION,
             MOVE_SPEED,
             Color.PINK,
             new Pinky(),
-            new Point(GameMap.getInstance().getMapWidthTile() - 1, 0));
+            new TileIndex(GameMap.getInstance().getMapWidthTile() - 1, 0));
     public static final Ghost INKY = new Ghost(
-            new Point(TILE_SIZE *12, TILE_SIZE *14),
+            new TileIndex(12, 14).toPosition(),
             DEFAULT_ORIENTATION,
             MOVE_SPEED,
             Color.CYAN,
             new Inky(),
-            new Point(GameMap.getInstance().getMapWidthTile() - 1, GameMap.getInstance().getMapHeightTile() - 1));
+            new TileIndex(GameMap.getInstance().getMapWidthTile() - 1, GameMap.getInstance().getMapHeightTile() - 1));
     public static final Ghost CLYDE = new Ghost(
-            new Point(TILE_SIZE *15, TILE_SIZE *14),
+            new TileIndex(15, 14).toPosition(),
             DEFAULT_ORIENTATION,
             MOVE_SPEED,
             Color.ORANGE,
             new Clyde(),
-            new Point(0, GameMap.getInstance().getMapHeightTile() - 1));
+            new TileIndex(0, GameMap.getInstance().getMapHeightTile() - 1));
 
     private final GameMap gameMap;
     private final Set<Pellet> pellets;
@@ -100,7 +100,7 @@ public class GamePanel extends JPanel implements Runnable {
     private void drawMap(Graphics2D g2d) {
         for (int y = 0; y < gameMap.getMapHeightTile(); y++) {
             for (int x = 0; x < gameMap.getMapWidthTile(); x++) {
-                TileType currentTile = gameMap.getTile(new Point(x,y));
+                TileType currentTile = gameMap.getTile(new TileIndex(x,y));
                 if (currentTile == TileType.PATH
                         || currentTile == TileType.OUTOFBOUNDS) {
                     g2d.setColor(Color.BLACK);
@@ -369,12 +369,12 @@ public class GamePanel extends JPanel implements Runnable {
 
     private void drawWallShape(int x, int y, Graphics2D g2d) {
         Map<String, TileType> neighbours = new HashMap<>();
-        neighbours.put("above",gameMap.getTile(new Point(x, y-1)));
-        neighbours.put("left",gameMap.getTile(new Point(x-1, y)));
-        neighbours.put("below",gameMap.getTile(new Point(x, y+1)));
+        neighbours.put("above",gameMap.getTile(new TileIndex(x, y-1)));
+        neighbours.put("left",gameMap.getTile(new TileIndex(x-1, y)));
+        neighbours.put("below",gameMap.getTile(new TileIndex(x, y+1)));
 
         g2d.setColor(Color.BLUE);
-        switch(gameMap.getTile(new Point(x,y))){
+        switch(gameMap.getTile(new TileIndex(x,y))){
             case DOUBLEHORIZONTALWALL ->
                 drawDoubleHorizontalWall(
                         neighbours.get("above")==TileType.PATH,
@@ -529,15 +529,16 @@ public class GamePanel extends JPanel implements Runnable {
     private void drawGhostScaredFace(Graphics2D g2d, Ghost ghost) {
         g2d.setColor(Color.PINK);
         int eyeSize = 2* TILE_SIZE /16;
-        Point leftEyePosition = new Point(ghost.getPosition().x + 5* TILE_SIZE /16, ghost.getPosition().y + 6* TILE_SIZE /16);
-        Point rightEyeOffset = new Point(3* TILE_SIZE /16 + eyeSize, 0);
+        Position leftEyePosition = new Position(ghost.getPosition().x + 5* TILE_SIZE /16, ghost.getPosition().y + 6* TILE_SIZE /16);
+        Position rightEyeOffset = new Position(3* TILE_SIZE /16 + eyeSize, 0);
+        Position rightEyePosition = rightEyeOffset.add(leftEyePosition);
         g2d.fillRect(leftEyePosition.x,
                 leftEyePosition.y,
                 eyeSize, eyeSize);
-        g2d.fillRect(leftEyePosition.x + rightEyeOffset.x,
-                leftEyePosition.y + rightEyeOffset.y,
+        g2d.fillRect(rightEyePosition.x,
+                rightEyePosition.y,
                 eyeSize, eyeSize);
-        Point mouthLeftCorner = new Point (ghost.getPosition().x + 3 * TILE_SIZE / 16, ghost.getPosition().y + 11* TILE_SIZE /16);
+        Position mouthLeftCorner = new Position (ghost.getPosition().x + 3 * TILE_SIZE / 16, ghost.getPosition().y + 11* TILE_SIZE /16);
         g2d.drawLine(mouthLeftCorner.x,
                 mouthLeftCorner.y,
                 mouthLeftCorner.x + TILE_SIZE / 16,
@@ -609,49 +610,50 @@ public class GamePanel extends JPanel implements Runnable {
         int eyeHeight = 6* TILE_SIZE /16;
         int eyeWidth = 4* TILE_SIZE /16;
         int pupilSize = 2* TILE_SIZE /16;
-        Point leftEyePosition = new Point(ghost.getPosition().x + 4* TILE_SIZE /16, ghost.getPosition().y + 4* TILE_SIZE /16);
-        Point rightEyeOffset = new Point(TILE_SIZE /16 + eyeWidth, 0);
-        Point leftPupilPosition = new Point(ghost.getPosition().x + 6* TILE_SIZE /16, ghost.getPosition().y + 6* TILE_SIZE /16);
-        Point[] orientationOffsets = getEyeAndPupilOrientationOffset(ghost.getOrientation());
+        Position leftEyePosition = new Position(ghost.getPosition().x + 4* TILE_SIZE /16, ghost.getPosition().y + 4* TILE_SIZE /16);
+        Position rightEyePosition = new Position(TILE_SIZE /16 + eyeWidth, 0).add(leftEyePosition);
+        Position leftPupilPosition = new Position(ghost.getPosition().x + 6* TILE_SIZE /16, ghost.getPosition().y + 6* TILE_SIZE /16);
+        Position rightPupilPosition = new Position(TILE_SIZE /16 + eyeWidth, 0).add(leftPupilPosition);
+        Position[] orientationOffsets = getEyeAndPupilOrientationOffset(ghost.getOrientation());
 
-        leftEyePosition.x += orientationOffsets[0].x;
-        leftEyePosition.y += orientationOffsets[0].y;
-        leftPupilPosition.x += orientationOffsets[1].x;
-        leftPupilPosition.y += orientationOffsets[1].y;
+        leftEyePosition.add(orientationOffsets[0]);
+        leftPupilPosition.add(orientationOffsets[1]);
+        rightEyePosition.add(orientationOffsets[0]);
+        rightPupilPosition.add(orientationOffsets[1]);
 
         g2d.fillArc(leftEyePosition.x,
                 leftEyePosition.y,
                 eyeWidth, eyeHeight, 0, 360);
-        g2d.fillArc(leftEyePosition.x + rightEyeOffset.x,
-                leftEyePosition.y + rightEyeOffset.y,
+        g2d.fillArc(rightEyePosition.x,
+                rightEyePosition.y,
                 eyeWidth, eyeHeight, 0, 360);
         g2d.setColor(Color.BLUE);
         g2d.fillArc(leftPupilPosition.x,
                 leftPupilPosition.y,
                 pupilSize, pupilSize, 0, 360);
-        g2d.fillArc(leftPupilPosition.x + rightEyeOffset.x,
-                leftPupilPosition.y + rightEyeOffset.y,
+        g2d.fillArc(rightPupilPosition.x,
+                rightPupilPosition.y,
                 pupilSize, pupilSize, 0, 360);
 
     }
 
-    private Point[] getEyeAndPupilOrientationOffset(Orientation orientation) {
-        Point eyeOrientationOffset;
-        Point pupilOrientationOffset;
+    private Position[] getEyeAndPupilOrientationOffset(Orientation orientation) {
+        Position eyeOrientationOffset;
+        Position pupilOrientationOffset;
         if (orientation == Orientation.UP) {
-            eyeOrientationOffset = new Point(-TILE_SIZE /16, -TILE_SIZE /8);
-            pupilOrientationOffset = new Point(-TILE_SIZE /8, -TILE_SIZE /4);
+            eyeOrientationOffset = new Position(-TILE_SIZE /16, -TILE_SIZE /8);
+            pupilOrientationOffset = new Position(-TILE_SIZE /8, -TILE_SIZE /4);
         } else if (orientation == Orientation.LEFT) {
-            eyeOrientationOffset = new Point(-TILE_SIZE /8, 0);
-            pupilOrientationOffset = new Point(-TILE_SIZE /4, 0);
+            eyeOrientationOffset = new Position(-TILE_SIZE /8, 0);
+            pupilOrientationOffset = new Position(-TILE_SIZE /4, 0);
         } else if (orientation == Orientation.DOWN) {
-            eyeOrientationOffset = new Point(-TILE_SIZE /16, TILE_SIZE /16);
-            pupilOrientationOffset = new Point(-2* TILE_SIZE /16, 3* TILE_SIZE /16);
+            eyeOrientationOffset = new Position(-TILE_SIZE /16, TILE_SIZE /16);
+            pupilOrientationOffset = new Position(-2* TILE_SIZE /16, 3* TILE_SIZE /16);
         } else {
-            eyeOrientationOffset = new Point(0,0);
-            pupilOrientationOffset = new Point(0, 0);
+            eyeOrientationOffset = new Position(0,0);
+            pupilOrientationOffset = new Position(0, 0);
         }
-        return new Point[]{eyeOrientationOffset, pupilOrientationOffset};
+        return new Position[]{eyeOrientationOffset, pupilOrientationOffset};
     }
 
     private void drawPacMan(Graphics2D g2d) {
@@ -677,30 +679,32 @@ public class GamePanel extends JPanel implements Runnable {
     private void drawPellets(Graphics2D g2d) {
         g2d.setColor(Color.PINK);
         for(Pellet pellet : pellets) {
+            Position pelletPosition = pellet.getTileIndex().toPosition();
             if (pellet.isPowerPellet())
-                g2d.fillOval(pellet.getTileIndex().x * TILE_SIZE + powerPelletOffset,
-                        pellet.getTileIndex().y * TILE_SIZE + powerPelletOffset,
+                g2d.fillOval(pelletPosition.x + powerPelletOffset,
+                        pelletPosition.y + powerPelletOffset,
                         powerPelletSize,
                         powerPelletSize);
             else
-                g2d.fillRect(pellet.getTileIndex().x * TILE_SIZE + pelletOffset,
-                        pellet.getTileIndex().y * TILE_SIZE + pelletOffset,
+                g2d.fillRect(pelletPosition.x + pelletOffset,
+                        pelletPosition.y + pelletOffset,
                         pelletSize,
                         pelletSize);
         }
     }
 
     private Rectangle getPelletHitBox(Pellet pellet) {
+        Position pelletPosition = pellet.getTileIndex().toPosition();
         if (pellet.isPowerPellet()) {
             return new Rectangle(
-                    pellet.getTileIndex().x * TILE_SIZE + powerPelletOffset,
-                    pellet.getTileIndex().y * TILE_SIZE + powerPelletOffset,
+                    pelletPosition.x + powerPelletOffset,
+                    pelletPosition.y + powerPelletOffset,
                     powerPelletSize,
                     powerPelletSize);
         } else {
             return new Rectangle(
-                    pellet.getTileIndex().x * TILE_SIZE + pelletOffset,
-                    pellet.getTileIndex().y * TILE_SIZE + pelletOffset,
+                    pelletPosition.x + pelletOffset,
+                    pelletPosition.y + pelletOffset,
                     pelletSize,
                     pelletSize);
         }

--- a/src/main/java/fr/LaurentFE/pacManClone/PacMan.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/PacMan.java
@@ -11,7 +11,7 @@ public class PacMan {
     private final Rectangle hitBox;
     private final GameMap gameMap;
 
-    public PacMan(Point startingPosition, Orientation startingOrientation, int moveSpeed) {
+    public PacMan(Position startingPosition, Orientation startingOrientation, int moveSpeed) {
         hitBox = new Rectangle(startingPosition.x, startingPosition.y, GamePanel.TILE_SIZE, GamePanel.TILE_SIZE);
         orientation = startingOrientation;
         this.moveSpeed = moveSpeed;
@@ -44,15 +44,16 @@ public class PacMan {
             }
     }
 
-    public void bumpOutOfCollision(Point collisionTileMapPosition) {
+    public void bumpOutOfCollision(TileIndex collisionTileIndex) {
+        Position collisionTilePosition = collisionTileIndex.toPosition();
         if (orientation == Orientation.LEFT) {
-            hitBox.x = collisionTileMapPosition.x * GamePanel.TILE_SIZE + GamePanel.TILE_SIZE;
+            hitBox.x = collisionTilePosition.x + GamePanel.TILE_SIZE;
         } else if (orientation == Orientation.RIGHT) {
-            hitBox.x = collisionTileMapPosition.x * GamePanel.TILE_SIZE - GamePanel.TILE_SIZE;
+            hitBox.x = collisionTilePosition.x - GamePanel.TILE_SIZE;
         } else if (orientation == Orientation.UP) {
-            hitBox.y = collisionTileMapPosition.y * GamePanel.TILE_SIZE + GamePanel.TILE_SIZE;
+            hitBox.y = collisionTilePosition.y + GamePanel.TILE_SIZE;
         } else if (orientation == Orientation.DOWN) {
-            hitBox.y = collisionTileMapPosition.y * GamePanel.TILE_SIZE - GamePanel.TILE_SIZE;
+            hitBox.y = collisionTilePosition.y - GamePanel.TILE_SIZE;
         }
     }
 
@@ -64,57 +65,58 @@ public class PacMan {
         return currentMouthAngle;
     }
 
-    public Point getPosition() {
-        return hitBox.getLocation();
+    public Position getPosition() {
+        return new Position(hitBox.x, hitBox.y);
     }
 
     private Rectangle getNextPathTileForOrientation(Orientation nextOrientation) {
-        Point directionModifier;
+        TileIndex directionModifier;
         if (nextOrientation == Orientation.UP) {
-            directionModifier = new Point(0, -1);
+            directionModifier = new TileIndex(0, -1);
         } else if (nextOrientation == Orientation.LEFT) {
-            directionModifier = new Point(-1, 0);
+            directionModifier = new TileIndex(-1, 0);
         } else if (nextOrientation == Orientation.DOWN) {
-            directionModifier = new Point(0, 1);
+            directionModifier = new TileIndex(0, 1);
         } else {
-            directionModifier = new Point(1, 0);
+            directionModifier = new TileIndex(1, 0);
         }
-        Point tileAPosition = new Point(
-                hitBox.x / GamePanel.TILE_SIZE + directionModifier.x,
-                hitBox.y / GamePanel.TILE_SIZE + directionModifier.y);
-        Point tileBPosition = new Point(
-                hitBox.x / GamePanel.TILE_SIZE + directionModifier.x,
-                hitBox.y / GamePanel.TILE_SIZE + directionModifier.y);
-        Point tileCPosition = new Point(
-                hitBox.x / GamePanel.TILE_SIZE + directionModifier.x,
-                hitBox.y / GamePanel.TILE_SIZE + directionModifier.y);
+        TileIndex tileAIndex = new Position(hitBox.x, hitBox.y).toTileIndex()
+                .add(directionModifier);
+        TileIndex tileBIndex = new Position(hitBox.x, hitBox.y).toTileIndex()
+                .add(directionModifier);
+        TileIndex tileCIndex = new Position(hitBox.x, hitBox.y).toTileIndex()
+                .add(directionModifier);
 
         if (nextOrientation == Orientation.UP || nextOrientation == Orientation.DOWN) {
-            tileAPosition.x -= 1;
-            tileCPosition.x += 1;
+            tileAIndex.x -= 1;
+            tileCIndex.x += 1;
         } else {
-            tileAPosition.y -= 1;
-            tileCPosition.y += 1;
+            tileAIndex.y -= 1;
+            tileCIndex.y += 1;
         }
 
-        if (canGoThroughTile(tileAPosition)) {
+        Position tileAPosition = tileAIndex.toPosition();
+        Position tileBPosition = tileBIndex.toPosition();
+        Position tileCPosition = tileCIndex.toPosition();
+
+        if (canGoThroughTile(tileAIndex)) {
             return new Rectangle(
-                    tileAPosition.x * GamePanel.TILE_SIZE,
-                    tileAPosition.y * GamePanel.TILE_SIZE,
+                    tileAPosition.x,
+                    tileAPosition.y,
                     GamePanel.TILE_SIZE,
                     GamePanel.TILE_SIZE
             );
-        } else if (canGoThroughTile(tileBPosition)) {
+        } else if (canGoThroughTile(tileBIndex)) {
             return new Rectangle(
-                    tileBPosition.x * GamePanel.TILE_SIZE,
-                    tileBPosition.y * GamePanel.TILE_SIZE,
+                    tileBPosition.x,
+                    tileBPosition.y,
                     GamePanel.TILE_SIZE,
                     GamePanel.TILE_SIZE
             );
-        } else if (canGoThroughTile(tileCPosition)) {
+        } else if (canGoThroughTile(tileCIndex)) {
             return new Rectangle(
-                    tileCPosition.x * GamePanel.TILE_SIZE,
-                    tileCPosition.y * GamePanel.TILE_SIZE,
+                    tileCPosition.x,
+                    tileCPosition.y,
                     GamePanel.TILE_SIZE,
                     GamePanel.TILE_SIZE
             );
@@ -147,18 +149,10 @@ public class PacMan {
 
     private void updatePosition() {
         move();
-        Point upperLeftTile = new Point(
-                (hitBox.x / GamePanel.TILE_SIZE),
-                (hitBox.y / GamePanel.TILE_SIZE));
-        Point upperRightTile = new Point(
-                ((hitBox.x + hitBox.width-1) / GamePanel.TILE_SIZE),
-                (hitBox.y / GamePanel.TILE_SIZE));
-        Point lowerLeftTile = new Point(
-                (hitBox.x / GamePanel.TILE_SIZE),
-                ((hitBox.y + hitBox.height-1) / GamePanel.TILE_SIZE));
-        Point lowerRightTile = new Point(
-                ((hitBox.x + hitBox.width-1) / GamePanel.TILE_SIZE),
-                ((hitBox.y + hitBox.height-1) / GamePanel.TILE_SIZE));
+        TileIndex upperLeftTile = new Position(hitBox.x,hitBox.y).toTileIndex();
+        TileIndex upperRightTile = new Position(hitBox.x + hitBox.width-1, hitBox.y).toTileIndex();
+        TileIndex lowerLeftTile = new Position(hitBox.x, hitBox.y + hitBox.height-1).toTileIndex();
+        TileIndex lowerRightTile = new Position(hitBox.x + hitBox.width-1,hitBox.y + hitBox.height-1).toTileIndex();
 
         if (!canGoThroughTile(upperLeftTile)) {
             bumpOutOfCollision(upperLeftTile);
@@ -173,9 +167,9 @@ public class PacMan {
         }
     }
 
-    public boolean canGoThroughTile(Point tileCoords) {
-        return gameMap.getTile(tileCoords) == TileType.PATH
-                || gameMap.getTile(tileCoords) == TileType.GHOSTHOUSE;
+    public boolean canGoThroughTile(TileIndex tileIndex) {
+        return gameMap.getTile(tileIndex) == TileType.PATH
+                || gameMap.getTile(tileIndex) == TileType.GHOSTHOUSE;
     }
 
     private boolean tryToChangeDirection(Orientation nextOrientation) {

--- a/src/main/java/fr/LaurentFE/pacManClone/Pellet.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/Pellet.java
@@ -1,19 +1,17 @@
 package fr.LaurentFE.pacManClone;
 
-import java.awt.*;
-
 public class Pellet {
-    private final Point tileIndex;
+    private final TileIndex tileIndex;
     private final int score;
     private final boolean isPowerPellet;
 
     public Pellet(int x, int y, boolean isPowerPellet) {
-        tileIndex = new Point(x, y);
+        tileIndex = new TileIndex(x, y);
         score = (isPowerPellet)?50:10;
         this.isPowerPellet = isPowerPellet;
     }
 
-    public Point getTileIndex() {
+    public TileIndex getTileIndex() {
         return tileIndex;
     }
 

--- a/src/main/java/fr/LaurentFE/pacManClone/Position.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/Position.java
@@ -1,0 +1,25 @@
+package fr.LaurentFE.pacManClone;
+
+public class Position {
+    public int x;
+    public int y;
+
+    public Position(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public TileIndex toTileIndex() {
+        return new TileIndex(x/GamePanel.TILE_SIZE, y/GamePanel.TILE_SIZE);
+    }
+
+    public String toString() {
+        return "Position["+x+", "+y+"]";
+    }
+
+    public Position add(Position p) {
+        x += p.x;
+        y += p.y;
+        return this;
+    }
+}

--- a/src/main/java/fr/LaurentFE/pacManClone/TileIndex.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/TileIndex.java
@@ -1,0 +1,25 @@
+package fr.LaurentFE.pacManClone;
+
+public class TileIndex {
+    public int x;
+    public int y;
+
+    public TileIndex(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public Position toPosition() {
+        return new Position(x*GamePanel.TILE_SIZE, y*GamePanel.TILE_SIZE);
+    }
+
+    public String toString() {
+        return "TileIndex["+x+", "+y+"]";
+    }
+
+    public TileIndex add(TileIndex ti) {
+        x += ti.x;
+        y += ti.y;
+        return this;
+    }
+}

--- a/src/main/java/fr/LaurentFE/pacManClone/ghost/personality/Blinky.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/ghost/personality/Blinky.java
@@ -2,8 +2,7 @@ package fr.LaurentFE.pacManClone.ghost.personality;
 
 import fr.LaurentFE.pacManClone.GamePanel;
 import fr.LaurentFE.pacManClone.Orientation;
-
-import java.awt.*;
+import fr.LaurentFE.pacManClone.TileIndex;
 
 public final class Blinky implements GhostPersonality {
 
@@ -11,10 +10,8 @@ public final class Blinky implements GhostPersonality {
 
     @Override
     public Orientation getNextMovementOrientation() {
-        Point targetTile = GamePanel.PAC_MAN.getPosition();
-        targetTile.x = targetTile.x / GamePanel.TILE_SIZE;
-        targetTile.y = targetTile.y / GamePanel.TILE_SIZE;
-        Point nextMoveTile = GamePanel.BLINKY.getNextMoveTile(targetTile);
+        TileIndex targetTile = GamePanel.PAC_MAN.getPosition().toTileIndex();
+        TileIndex nextMoveTile = GamePanel.BLINKY.getNextMoveTile(targetTile);
 
         return GamePanel.BLINKY.getOrientationToGoToTile(nextMoveTile);
     }

--- a/src/main/java/fr/LaurentFE/pacManClone/ghost/personality/Clyde.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/ghost/personality/Clyde.java
@@ -2,8 +2,8 @@ package fr.LaurentFE.pacManClone.ghost.personality;
 
 import fr.LaurentFE.pacManClone.GamePanel;
 import fr.LaurentFE.pacManClone.Orientation;
+import fr.LaurentFE.pacManClone.TileIndex;
 
-import java.awt.*;
 
 public class Clyde implements GhostPersonality {
 
@@ -12,10 +12,8 @@ public class Clyde implements GhostPersonality {
     @Override
     public Orientation getNextMovementOrientation() {
         if (getSquareDistanceFromPacMan() >= 64) {
-            Point targetTile = GamePanel.PAC_MAN.getPosition();
-            targetTile.x = targetTile.x / GamePanel.TILE_SIZE;
-            targetTile.y = targetTile.y / GamePanel.TILE_SIZE;
-            Point nextMoveTile = GamePanel.CLYDE.getNextMoveTile(targetTile);
+            TileIndex targetTile = GamePanel.PAC_MAN.getPosition().toTileIndex();
+            TileIndex nextMoveTile = GamePanel.CLYDE.getNextMoveTile(targetTile);
 
             return GamePanel.CLYDE.getOrientationToGoToTile(nextMoveTile);
         } else {
@@ -24,10 +22,10 @@ public class Clyde implements GhostPersonality {
     }
 
     private int getSquareDistanceFromPacMan() {
-        Point dist = new Point(
-                GamePanel.PAC_MAN.getPosition().x / GamePanel.TILE_SIZE - GamePanel.CLYDE.getPosition().x / GamePanel.TILE_SIZE,
-                GamePanel.PAC_MAN.getPosition().y / GamePanel.TILE_SIZE - GamePanel.CLYDE.getPosition().y / GamePanel.TILE_SIZE);
+        TileIndex pacManTile = GamePanel.PAC_MAN.getPosition().toTileIndex();
+        TileIndex clydeTile = GamePanel.CLYDE.getPosition().toTileIndex();
 
-        return dist.x * dist.x + dist.y * dist.y;
+        return (pacManTile.x - clydeTile.x)*(pacManTile.x - clydeTile.x)
+                + (pacManTile.y - clydeTile.y)*(pacManTile.y - clydeTile.y);
     }
 }

--- a/src/main/java/fr/LaurentFE/pacManClone/ghost/personality/Inky.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/ghost/personality/Inky.java
@@ -2,8 +2,7 @@ package fr.LaurentFE.pacManClone.ghost.personality;
 
 import fr.LaurentFE.pacManClone.GamePanel;
 import fr.LaurentFE.pacManClone.Orientation;
-
-import java.awt.*;
+import fr.LaurentFE.pacManClone.TileIndex;
 
 public class Inky implements GhostPersonality {
 
@@ -11,25 +10,19 @@ public class Inky implements GhostPersonality {
 
     @Override
     public Orientation getNextMovementOrientation() {
-        Point pacManTile = GamePanel.PAC_MAN.getPosition();
-        pacManTile.x = pacManTile.x / GamePanel.TILE_SIZE;
-        pacManTile.y = pacManTile.y / GamePanel.TILE_SIZE;
+        TileIndex pacManTile = GamePanel.PAC_MAN.getPosition().toTileIndex();
         switch (GamePanel.PAC_MAN.getOrientation()) {
             case UP -> pacManTile.y -= 2;
             case LEFT -> pacManTile.x -= 2;
             case DOWN -> pacManTile.y += 2;
             case RIGHT -> pacManTile.x += 2;
         }
-        Point blinkyTile = GamePanel.BLINKY.getPosition();
-        blinkyTile.x = pacManTile.x / GamePanel.TILE_SIZE;
-        blinkyTile.y = pacManTile.y / GamePanel.TILE_SIZE;
-        Point targetTile = new Point(
-                -(blinkyTile.x - pacManTile.x),
-                -(blinkyTile.y - pacManTile.y));
+        TileIndex blinkyTile = GamePanel.BLINKY.getPosition().toTileIndex();
+        TileIndex targetTile = new TileIndex(
+                blinkyTile.x - 2*(blinkyTile.x- pacManTile.x),
+                blinkyTile.y - 2*(blinkyTile.y- pacManTile.y));
 
-
-        Point nextMoveTile = GamePanel.INKY.getNextMoveTile(targetTile);
-
+        TileIndex nextMoveTile = GamePanel.INKY.getNextMoveTile(new TileIndex(targetTile.x, targetTile.y));
 
         return GamePanel.INKY.getOrientationToGoToTile(nextMoveTile);
     }

--- a/src/main/java/fr/LaurentFE/pacManClone/ghost/personality/Pinky.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/ghost/personality/Pinky.java
@@ -2,8 +2,8 @@ package fr.LaurentFE.pacManClone.ghost.personality;
 
 import fr.LaurentFE.pacManClone.GamePanel;
 import fr.LaurentFE.pacManClone.Orientation;
+import fr.LaurentFE.pacManClone.TileIndex;
 
-import java.awt.*;
 
 public class Pinky implements GhostPersonality {
 
@@ -11,16 +11,14 @@ public class Pinky implements GhostPersonality {
 
     @Override
     public Orientation getNextMovementOrientation() {
-        Point targetTile = GamePanel.PAC_MAN.getPosition();
-        targetTile.x = targetTile.x / GamePanel.TILE_SIZE;
-        targetTile.y = targetTile.y / GamePanel.TILE_SIZE;
+        TileIndex targetTile = GamePanel.PAC_MAN.getPosition().toTileIndex();
         switch (GamePanel.PAC_MAN.getOrientation()) {
             case UP -> targetTile.y -= 4;
             case LEFT -> targetTile.x -= 4;
             case DOWN -> targetTile.y +=4;
             case RIGHT -> targetTile.x +=4;
         }
-        Point nextMoveTile = GamePanel.PINKY.getNextMoveTile(targetTile);
+        TileIndex nextMoveTile = GamePanel.PINKY.getNextMoveTile(targetTile);
 
         return GamePanel.PINKY.getOrientationToGoToTile(nextMoveTile);
     }


### PR DESCRIPTION
Created classes TileIndex and Position.\
Changed all java.awt.Point usages for TileIndex and Position classes instead, for better code clarity.

Refacto pointed at and fixed a bug in Inky's getNextMovementOrientation() where we used to wrongfully replace Blinky's position by PacMan's, and the formula to calculate the target tile was wrong.