### PR TITLE
Fix - PacMan Death - infinite animateDeath()

### DIFF
--- a/src/main/java/fr/LaurentFE/pacManClone/entities/PacMan.java
+++ b/src/main/java/fr/LaurentFE/pacManClone/entities/PacMan.java
@@ -219,6 +219,8 @@ public class PacMan {
 
     private boolean animateDeath() {
         orientation = Orientation.UP;
+        if (mouthAngleIncrement < 0)
+            mouthAngleIncrement *= -1;
         currentMouthAngle += mouthAngleIncrement;
         return currentMouthAngle >= 360;
     }


### PR DESCRIPTION
PacMan.animateDeath() could fall in a never ending return true state if the mouthAngleIncrement was negative in the animation of PacMan when still alive.\
Now the mouthAngleIncrement is checked and corrected if negative.